### PR TITLE
Fix typographical error

### DIFF
--- a/sacp.go
+++ b/sacp.go
@@ -178,7 +178,7 @@ func SACP_connect(ip string, timeout time.Duration) (net.Conn, error) {
 	for {
 		p, err := SACP_read(conn, timeout)
 		if err != nil || p == nil {
-			// log.Println("Error reading \"hello\" responce: ", err)
+			// log.Println("Error reading \"hello\" response: ", err)
 			conn.Close()
 			return nil, err
 		}
@@ -341,7 +341,7 @@ func SACP_start_upload(conn net.Conn, filename string, gcode []byte, timeout tim
 	}
 
 	for {
-		// always receive packet, then send responce
+		// always receive packet, then send response
 		conn.SetReadDeadline(time.Now().Add(timeout))
 		p, err := SACP_read(conn, time.Second*10)
 		if err != nil {


### PR DESCRIPTION
## Summary
- correct spelling of `response` in `sacp.go`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68401ea23dfc832a8f43e2a3d9ce5a88