### PR TITLE
Fix SACP decode header check

### DIFF
--- a/sacp.go
+++ b/sacp.go
@@ -70,7 +70,8 @@ func (sacp *SACP_pack) Decode(data []byte) error {
 	if len(data) < 13 {
 		return errInvalidSize
 	}
-	if data[0] != 0xAA && data[1] != 0x55 {
+	// ensure the packet starts with the expected 0xAA55 header bytes
+	if data[0] != 0xAA || data[1] != 0x55 {
 		return errInvalidSACP
 	}
 	dataLen := binary.LittleEndian.Uint16(data[2:4])


### PR DESCRIPTION
## Summary
- ensure either header byte triggers `errInvalidSACP`
- document the `0xAA55` magic check

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68401ea0333c832aa4872c8917712ab4