### PR TITLE
Add Decode tests and header validation fix

### DIFF
--- a/sacp.go
+++ b/sacp.go
@@ -70,6 +70,7 @@ func (sacp *SACP_pack) Decode(data []byte) error {
 	if len(data) < 13 {
 		return errInvalidSize
 	}
+	// ensure the packet starts with the expected 0xAA55 header bytes
 	if data[0] != 0xAA || data[1] != 0x55 {
 		return errInvalidSACP
 	}

--- a/sacp.go
+++ b/sacp.go
@@ -70,7 +70,7 @@ func (sacp *SACP_pack) Decode(data []byte) error {
 	if len(data) < 13 {
 		return errInvalidSize
 	}
-	if data[0] != 0xAA && data[1] != 0x55 {
+	if data[0] != 0xAA || data[1] != 0x55 {
 		return errInvalidSACP
 	}
 	dataLen := binary.LittleEndian.Uint16(data[2:4])

--- a/sacp_test.go
+++ b/sacp_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestSACPDecodeValid(t *testing.T) {
+	orig := SACP_pack{
+		ReceiverID: 1,
+		SenderID:   2,
+		Attribute:  0,
+		Sequence:   0x1234,
+		CommandSet: 0x56,
+		CommandID:  0x78,
+		Data:       []byte{0x9a, 0xbc},
+	}
+
+	encoded := orig.Encode()
+
+	var got SACP_pack
+	if err := got.Decode(encoded); err != nil {
+		t.Fatalf("Decode returned error: %v", err)
+	}
+
+	if got.ReceiverID != orig.ReceiverID ||
+		got.SenderID != orig.SenderID ||
+		got.Attribute != orig.Attribute ||
+		got.Sequence != orig.Sequence ||
+		got.CommandSet != orig.CommandSet ||
+		got.CommandID != orig.CommandID ||
+		string(got.Data) != string(orig.Data) {
+		t.Fatalf("Decoded packet mismatch: %+v vs %+v", got, orig)
+	}
+}
+
+func TestSACPDecodeInvalidHeader(t *testing.T) {
+	p := SACP_pack{ReceiverID: 1, SenderID: 2, Attribute: 0, Sequence: 1}
+	encoded := p.Encode()
+
+	encoded[0] ^= 0xff // corrupt first header byte
+
+	var got SACP_pack
+	err := got.Decode(encoded)
+	if err != errInvalidSACP {
+		t.Fatalf("expected errInvalidSACP, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for `SACP_pack.Decode`
- fix header validation logic in `Decode`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68401e9e39b8832ab59289957d835c4a