### PR TITLE
Fix typo in SACP version error

### DIFF
--- a/sacp.go
+++ b/sacp.go
@@ -20,10 +20,10 @@ const (
 )
 
 var (
-	errInvalidSACP    = errors.New("data doesn't look like SACP packet")
-	errInvalidSACPVer = errors.New("SACP version missmatch")
-	errInvalidChksum  = errors.New("SACP checksum doesn't match data")
-	errInvalidSize    = errors.New("SACP package is too short")
+        errInvalidSACP    = errors.New("data doesn't look like SACP packet")
+        errInvalidSACPVer = errors.New("SACP version mismatch")
+        errInvalidChksum  = errors.New("SACP checksum doesn't match data")
+        errInvalidSize    = errors.New("SACP package is too short")
 )
 
 type SACP_pack struct {


### PR DESCRIPTION
## Summary
- correct error text for invalid SACP version
- run `go vet` to ensure no build issues

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68402a0df3f0832aa5ad7921eccc079c