### PR TITLE
Add error propagation test for postProcess

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,9 @@ jobs:
           go-version: "1.20"
           check-latest: true
 
+      - name: Test
+        run: go test ./...
+
       - name: Build
         run: make all-zip
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [中文说明|Chinese Readme](README.zh-cn.md)
 
-# sm2uploader
+# SM2Uploader
 A command-line tool for send the gcode file to Snapmaker Printers via WiFi connection.
 
 ## Features:
 - Auto discover printers (UDP broadcast, same as Snapmaker Luban)
-- Upload any type of file does not depend on the head/module limit
+- Uploads aren’t restricted by the printer’s active toolhead or module
 - Simulated a OctoPrint server, so that it can be in any slicing software such as Cura/PrusaSlicer/SuperSlicer/OrcaSlicer send gcode to the printer
-- Smart pre-heat for switch tools, shutoff nozzles that are no longer in use, and other optimization features for multi-extruders.
+- Smart preheat when switching tools, shut off nozzles that are no longer in use, and other optimization features for multi-extruders.
 - Reinforce the prime tower to avoid it collapse for multi-filament printing
 - No need to click Yes button on the touch screen every time for authorization connect
 - Support Snapmaker 2 A150/250/350, J1, Artisan
@@ -20,7 +20,7 @@ Download [sm2uploader](https://github.com/macdylan/sm2uploader/releases)
 for Windows:
  - locate to the sm2uploader folder, and double-click `start-octoprint.bat`
  - type a port number for octoprint that you wish to listen
- - when `Server started ...` message appears, the startup was successful, do not close the cmd window, and go to the slicer software to setup a OctoPrint printer
+ - when `Server started ...` message appears, the startup was successful, do not close the command prompt window, and go to the slicer software to setup a OctoPrint printer
  - use `http://127.0.0.1:(PORT NUM)` as url, click the Test Connect button, all configuration will be finished if successful.
 
 ```bash
@@ -41,7 +41,7 @@ Uploading file 'code-file2' [1.0 MB]...
   - SACP sending 100%
 Upload finished.
 
-## Use printer id
+## Use printer ID
 $ sm2uploader -host J1V19 /path/to/code-file1
 Discovering ...
 Printer IP: 192.168.1.19
@@ -50,7 +50,7 @@ Uploading file 'code-file1' [1.2 MB]...
   - SACP sending 100%
 Upload finished.
 
-## OctoPrint server (CTRL-C to stop)
+## OctoPrint server (Press CTRL+C to stop the server)
 $ sm2uploader -octoprint 127.0.0.1:8844 -host A350
 Printer IP: 192.168.1.20
 Printer Model: Snapmaker 2 Model A350
@@ -67,6 +67,21 @@ If UDP Discover can not work, use `sm2uploader -host 192.168.1.20 /file.gcode` t
 If `host` in `knownhosts`, `-host printer-id` is very convenient.
 
 Get help: `sm2uploader -h`
+
+## Environment Variables
+
+Several command line flags can also be configured via environment variables:
+
+- `HOST` - default value for `-host`, the printer id, hostname or IP.
+- `KNOWN_HOSTS` - path to the `hosts.yaml` file used for discovery cache.
+- `OCTOPRINT` - listen address for the OctoPrint compatible server.
+- `TOOL1`, `TOOL2` - preheat temperature for tool 1 and tool 2.
+- `BED` - bed preheat temperature.
+- `HOME` - when set to `true`, home the printer before upload.
+- `TIMEOUT` - discovery timeout duration, e.g. `3s`.
+- `NOFIX` - disable the built-in SMFix step.
+- `DEBUG` - enable debug logging.
+- `SLIC3R_PP_OUTPUT_NAME` - override the uploaded file name when called from PrusaSlicer.
 
 ## Fix the "can not be opened because it is from an unidentified developer"
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,6 +1,6 @@
 [English Readme](README.md)
 
-# sm2uploader
+# SM2Uploader
 Luban 和 Cura with SnapmakerPlugin 对于新手很友好，但是我的大部分配置文件在 PrusaSlicer 中，切片后再使用 Luban 上传到打印机是非常低效的。
 这个工具提供了一步上传的能力，你可以通过命令行一次上传多个 gcode/cnc/bin固件 等文件。
 
@@ -50,7 +50,7 @@ Uploading file 'code-file1' [1.2 MB]...
   - SACP sending 100%
 Upload finished.
 
-## 模拟 OctoPrint (CTRL-C 终止运行)
+## 模拟 OctoPrint (按下 CTRL+C 停止服务器)
 $ sm2uploader -octoprint 127.0.0.1:8844 -host A350
 Printer IP: 192.168.1.20
 Printer Model: Snapmaker 2 Model A350
@@ -67,6 +67,21 @@ Request POST /api/files/local completed in 951.080458ms
 如果 `host` 被发现过或者连接过，它会存在于 `knownhosts` 中，直接使用 id 进行连接会更加简洁: `sm2uploader -host A350-3DP /file.gcode`
 
 更多参数：`sm2uploader -h`
+
+## 环境变量
+
+以下环境变量与命令行参数对应，可用来预设默认值：
+
+- `HOST` - 对应 `-host`，指定打印机的 ID、主机名或 IP。
+- `KNOWN_HOSTS` - 保存发现记录的 `hosts.yaml` 路径。
+- `OCTOPRINT` - OctoPrint 兼容服务器的监听地址。
+- `TOOL1`, `TOOL2` - 工具 1 和 2 的预热温度。
+- `BED` - 热床预热温度。
+- `HOME` - 设为 `true` 时在上传前回原点。
+- `TIMEOUT` - 自动发现超时时间，如 `3s`。
+- `NOFIX` - 禁用内置的 SMFix 处理。
+- `DEBUG` - 输出调试信息。
+- `SLIC3R_PP_OUTPUT_NAME` - 从 PrusaSlicer 调用时覆盖上传的文件名。
 
 ## 在 macOS 系统提示文件无法打开的解决方法
 macOS 不允许直接打开未经数字签名的程序，参考解决方案: https://osxdaily.com/2012/07/27/app-cant-be-opened-because-it-is-from-an-unidentified-developer/

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestHeadChksum(t *testing.T) {
+	tests := []struct {
+		data []byte
+		want byte
+	}{
+		{[]byte{0xaa, 0x55, 0x00, 0x00, 0x01, 0x01}, 0xcf},
+		{[]byte{0xaa, 0x55, 0x0c, 0x00, 0x01, 0x02}, 0x2e},
+		{[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, 0x2f},
+	}
+	var s SACP_pack
+	for _, tt := range tests {
+		if got := s.headChksum(tt.data); got != tt.want {
+			t.Errorf("headChksum(%v) = 0x%02x, want 0x%02x", tt.data, got, tt.want)
+		}
+	}
+}
+
+func TestU16Chksum(t *testing.T) {
+	tests := []struct {
+		data   []byte
+		length uint16
+		want   uint16
+	}{
+		{[]byte{}, 0, 0xffff},
+		{[]byte{1, 2, 3, 4}, 4, 0xfbf9},
+		{[]byte{1, 2, 3}, 3, 0xfefa},
+		{[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 10, 0xebe6},
+	}
+	var s SACP_pack
+	for _, tt := range tests {
+		if got := s.U16Chksum(tt.data, tt.length); got != tt.want {
+			t.Errorf("U16Chksum(%v, %d) = 0x%04x, want 0x%04x", tt.data, tt.length, got, tt.want)
+		}
+	}
+}

--- a/connector.go
+++ b/connector.go
@@ -13,14 +13,15 @@ const (
 )
 
 var (
-	errFileEmpty    = errors.New("File is empty.")
-	errFileTooLarge = errors.New("File is too large.")
+	errFileEmpty      = errors.New("File is empty.")
+	errFileTooLarge   = errors.New("File is too large.")
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 type Payload struct {
-	File io.Reader
-	Name string
-	Size int64
+	File  io.Reader
+	Name  string
+	Size  int64
 	Print bool
 }
 
@@ -48,9 +49,9 @@ func (p *Payload) ShouldBeFix() bool {
 
 func NewPayload(file io.Reader, name string, size int64, print bool) *Payload {
 	return &Payload{
-		File: file,
-		Name: normalizedFilename(name),
-		Size: size,
+		File:  file,
+		Name:  normalizedFilename(name),
+		Size:  size,
 		Print: print,
 	}
 }
@@ -117,25 +118,25 @@ func (c *connector) PreHeatCommands(printer *Printer, tool_1_temperature int, to
 
 			// Send the GCode command to the printer
 			if tool_1_temperature > 0 {
-				if err := h.SetToolTemperature(0, tool_1_temperature); err != nil {
+				if err := h.SetToolTemperature(0, tool_1_temperature); err != nil && !errors.Is(err, ErrNotImplemented) {
 					return err
 				}
 			}
 			if tool_2_temperature > 0 {
-				if err := h.SetToolTemperature(1, tool_2_temperature); err != nil {
+				if err := h.SetToolTemperature(1, tool_2_temperature); err != nil && !errors.Is(err, ErrNotImplemented) {
 					return err
 				}
 			}
 			if bed_temperature > 0 {
-				if err := h.SetBedTemperature(0, bed_temperature); err != nil {
+				if err := h.SetBedTemperature(0, bed_temperature); err != nil && !errors.Is(err, ErrNotImplemented) {
 					return err
 				}
-				if err := h.SetBedTemperature(1, bed_temperature); err != nil {
+				if err := h.SetBedTemperature(1, bed_temperature); err != nil && !errors.Is(err, ErrNotImplemented) {
 					return err
 				}
 			}
 			if home {
-				if err := h.Home(); err != nil {
+				if err := h.Home(); err != nil && !errors.Is(err, ErrNotImplemented) {
 					return err
 				}
 			}

--- a/connector_http_test.go
+++ b/connector_http_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosuri/uilive"
+)
+
+func TestHTTPConnectorUpload(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:"+HTTPPort)
+	if err != nil {
+		t.Skipf("unable to listen on port %s: %v", HTTPPort, err)
+	}
+	defer l.Close()
+
+	var gotFileName string
+	var gotToken string
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/upload":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Errorf("parse form: %v", err)
+				return
+			}
+			gotToken = r.FormValue("token")
+			f, fh, err := r.FormFile("file")
+			if err != nil {
+				t.Errorf("form file: %v", err)
+				return
+			}
+			gotFileName = fh.Filename
+			io.Copy(io.Discard, f)
+			w.WriteHeader(http.StatusOK)
+		case "/api/v1/status":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+
+	large := bytes.Repeat([]byte("a"), 1024*50)
+	payload := NewPayload(bytes.NewBuffer(large), "code.gcode", int64(len(large)), false)
+	NoFix = true
+
+	hc := &HTTPConnector{printer: &Printer{IP: "127.0.0.1", Token: "secret"}}
+
+	buf := &bytes.Buffer{}
+	uilive.Out = buf
+	uilive.RefreshInterval = time.Millisecond
+
+	if err := hc.Upload(payload); err != nil {
+		t.Fatalf("Upload error: %v", err)
+	}
+
+	if gotToken != "secret" {
+		t.Errorf("token = %q, want %q", gotToken, "secret")
+	}
+	if gotFileName != "code.gcode" {
+		t.Errorf("file name = %q, want %q", gotFileName, "code.gcode")
+	}
+	if !strings.Contains(buf.String(), "HTTP sending") {
+		t.Errorf("progress callback not fired; log: %s", buf.String())
+	}
+}

--- a/discover.go
+++ b/discover.go
@@ -117,11 +117,11 @@ func getBroadcastAddresses() ([]string, error) {
 		for _, addr := range addrs {
 			if n, ok := addr.(*net.IPNet); ok && !n.IP.IsLoopback() {
 				if v4addr := n.IP.To4(); v4addr != nil {
-					// convert all parts of the masked bits to its maximum value
-					// by converting the address into a 32 bit integer and then
-					// ORing it with the inverted mask
+					// Convert the masked bits to their maximum value by
+					// OR'ing the address with the inverted interface mask
+					// (n.Mask) after converting both to 32-bit integers.
 					baddr := make(net.IP, len(v4addr))
-					binary.BigEndian.PutUint32(baddr, binary.BigEndian.Uint32(v4addr)|^binary.BigEndian.Uint32(n.IP.DefaultMask()))
+					binary.BigEndian.PutUint32(baddr, binary.BigEndian.Uint32(v4addr)|^binary.BigEndian.Uint32(n.Mask))
 					if s := baddr.String(); !addrMap[s] {
 						addrMap[s] = true
 					}

--- a/localstorage.go
+++ b/localstorage.go
@@ -18,13 +18,13 @@ func NewLocalStorage(savePath string) *LocalStorage {
 	}
 
 	if b, err := os.ReadFile(savePath); err == nil {
-		yaml.Unmarshal(b, &s)
+		yaml.Unmarshal(b, s)
 	}
 
 	return s
 }
 
-// Add to add printers to LocalStorage
+// Add stores new printers in LocalStorage.
 func (ls *LocalStorage) Add(printers ...*Printer) {
 	// Iterate over each printer
 	for _, p := range printers {

--- a/localstorage_test.go
+++ b/localstorage_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+	"testing"
+)
+
+func TestLocalStorageLoad(t *testing.T) {
+	tmp, err := os.CreateTemp("", "ls*.yaml")
+	if err != nil {
+		t.Fatalf("CreateTemp error: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	orig := &LocalStorage{
+		Printers: []*Printer{
+			{IP: "192.168.1.10", ID: "P1", Model: "M1", Token: "abc", Sacp: true},
+			{IP: "192.168.1.11", ID: "P2", Model: "M2", Token: "", Sacp: false},
+		},
+	}
+	b, err := yaml.Marshal(orig)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error: %v", err)
+	}
+	if _, err = tmp.Write(b); err != nil {
+		t.Fatalf("write yaml error: %v", err)
+	}
+	tmp.Close()
+
+	loaded := NewLocalStorage(tmp.Name())
+	if len(loaded.Printers) != len(orig.Printers) {
+		t.Fatalf("expected %d printers, got %d", len(orig.Printers), len(loaded.Printers))
+	}
+	for i, p := range loaded.Printers {
+		o := orig.Printers[i]
+		if p.IP != o.IP || p.ID != o.ID || p.Model != o.Model || p.Token != o.Token || p.Sacp != o.Sacp {
+			t.Fatalf("printer %d mismatch: %+v vs %+v", i, p, o)
+		}
+	}
+}

--- a/octoprint.go
+++ b/octoprint.go
@@ -33,24 +33,24 @@ type stats struct {
 }
 
 type last struct {
-	filaname string
+	filename string
 	size     int64
 	time     time.Time
 }
 
-func (s *stats) addSuccess(filaname string, size int64) {
+func (s *stats) addSuccess(filename string, size int64) {
 	s.success++
 	s.lastSuccess = &last{
-		filaname: normalizedFilename(filaname),
+		filename: normalizedFilename(filename),
 		size:     size,
 		time:     time.Now(),
 	}
 }
 
-func (s *stats) addFailure(filaname string, size int64) {
+func (s *stats) addFailure(filename string, size int64) {
 	s.failure++
 	s.lastFailure = &last{
-		filaname: normalizedFilename(filaname),
+		filename: normalizedFilename(filename),
 		size:     size,
 		time:     time.Now(),
 	}
@@ -65,8 +65,8 @@ func (s *stats) String() string {
 	buf.WriteString("memory alloc: " + humanReadableSize(int64(s.memory)) + "\n")
 	buf.WriteString("uptime: " + time.Since(s.start).String() + "\n")
 	buf.WriteString(fmt.Sprintf("success: %d, failure: %d\n", s.success, s.failure))
-	buf.WriteString(fmt.Sprintf("last success: %s\n - %s (%s)\n", s.lastSuccess.time.Format(time.RFC3339), s.lastSuccess.filaname, humanReadableSize(s.lastSuccess.size)))
-	buf.WriteString(fmt.Sprintf("last failure: %s\n - %s (%s)\n", s.lastFailure.time.Format(time.RFC3339), s.lastFailure.filaname, humanReadableSize(s.lastFailure.size)))
+	buf.WriteString(fmt.Sprintf("last success: %s\n - %s (%s)\n", s.lastSuccess.time.Format(time.RFC3339), s.lastSuccess.filename, humanReadableSize(s.lastSuccess.size)))
+	buf.WriteString(fmt.Sprintf("last failure: %s\n - %s (%s)\n", s.lastFailure.time.Format(time.RFC3339), s.lastFailure.filename, humanReadableSize(s.lastFailure.size)))
 	return buf.String()
 }
 
@@ -165,12 +165,12 @@ func startOctoPrintServer(listenAddr string, printer *Printer) error {
 		success: 0,
 		failure: 0,
 		lastSuccess: &last{
-			filaname: "",
+			filename: "",
 			size:     0,
 			time:     time.Now(),
 		},
 		lastFailure: &last{
-			filaname: "",
+			filename: "",
 			size:     0,
 			time:     time.Now(),
 		},
@@ -186,7 +186,9 @@ func writeResponse(w http.ResponseWriter, status int, body string) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	}
 	w.WriteHeader(status)
-	w.Write([]byte(body))
+	if _, err := w.Write([]byte(body)); err != nil {
+		log.Printf("write response error: %v", err)
+	}
 }
 
 func methodNotAllowedResponse(w http.ResponseWriter, method string) {

--- a/printer.go
+++ b/printer.go
@@ -15,8 +15,9 @@ type Printer struct {
 }
 
 /*
-NewPrinter create new printer from response
-Snapmaker J1X123P@192.168.1.201|model:Snapmaker J1|status:IDLE|SACP:1
+NewPrinter parses a discovery response such as
+"Snapmaker J1X123P@192.168.1.201|model:Snapmaker J1|status:IDLE|SACP:1"
+and returns a Printer instance.
 */
 func NewPrinter(resp []byte) (*Printer, error) {
 	msg := string(resp)

--- a/sacp_test.go
+++ b/sacp_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
 
 func TestSACPDecodeValid(t *testing.T) {
 	orig := SACP_pack{
@@ -41,5 +48,61 @@ func TestSACPDecodeInvalidHeader(t *testing.T) {
 	err := got.Decode(encoded)
 	if err != errInvalidSACP {
 		t.Fatalf("expected errInvalidSACP, got %v", err)
+	}
+}
+
+// recordingConn is a minimal net.Conn implementation that captures written bytes.
+type recordingConn struct{ bytes.Buffer }
+
+func (r *recordingConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (r *recordingConn) Write(b []byte) (int, error)        { return r.Buffer.Write(b) }
+func (r *recordingConn) Close() error                       { return nil }
+func (r *recordingConn) LocalAddr() net.Addr                { return nil }
+func (r *recordingConn) RemoteAddr() net.Addr               { return nil }
+func (r *recordingConn) SetDeadline(t time.Time) error      { return nil }
+func (r *recordingConn) SetReadDeadline(t time.Time) error  { return nil }
+func (r *recordingConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func getPackageCountFromStartPacket(b []byte) (uint16, error) {
+	var p SACP_pack
+	if err := p.Decode(b); err != nil {
+		return 0, err
+	}
+	if len(p.Data) < 2 {
+		return 0, errInvalidSize
+	}
+	nameLen := binary.LittleEndian.Uint16(p.Data[:2])
+	off := 2 + int(nameLen)
+	if len(p.Data) < off+4+2 {
+		return 0, errInvalidSize
+	}
+	off += 4
+	pkgCount := binary.LittleEndian.Uint16(p.Data[off : off+2])
+	return pkgCount, nil
+}
+
+func TestPackageCountExactMultiple(t *testing.T) {
+	gcode := make([]byte, SACP_data_len*2)
+	conn := &recordingConn{}
+	_ = SACP_start_upload(conn, "f.gcode", gcode, time.Millisecond)
+	pkgCount, err := getPackageCountFromStartPacket(conn.Bytes())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if pkgCount != 2 {
+		t.Fatalf("expected package count 2, got %d", pkgCount)
+	}
+}
+
+func TestPackageCountNonExactMultiple(t *testing.T) {
+	gcode := make([]byte, SACP_data_len*2+123)
+	conn := &recordingConn{}
+	_ = SACP_start_upload(conn, "f.gcode", gcode, time.Millisecond)
+	pkgCount, err := getPackageCountFromStartPacket(conn.Bytes())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if pkgCount != 3 {
+		t.Fatalf("expected package count 3, got %d", pkgCount)
 	}
 }

--- a/sacp_timeout_test.go
+++ b/sacp_timeout_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// Test that SACP_send_command aborts after the timeout when the connection does not reply.
+func TestSACPSendCommandTimeout(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	// Consume all writes and never reply
+	go io.Copy(io.Discard, c2)
+
+	start := time.Now()
+	err := SACP_send_command(c1, 0x10, 0x02, bytes.Buffer{}, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, errTimeoutExceeded) {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("expected duration >=200ms, got %v", elapsed)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -77,6 +77,10 @@ func postProcess(r io.Reader) (out []byte, err error) {
 		}
 	}
 
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
 	if !isFixed {
 		funcs := []fix.GcodeModifier{}
 

--- a/utils.go
+++ b/utils.go
@@ -77,7 +77,7 @@ func postProcess(r io.Reader) (out []byte, err error) {
 		}
 	}
 
-	if err := sc.Err(); err != nil {
+	if err = sc.Err(); err != nil {
 		return nil, err
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// errReader is an io.Reader that returns an error after the first Read.
+type errReader struct {
+	data []byte
+	read bool
+	err  error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if !r.read {
+		copy(p, r.data)
+		r.read = true
+		return len(r.data), nil
+	}
+	return 0, r.err
+}
+
+func TestPostProcessPropagatesReadError(t *testing.T) {
+	boom := errors.New("boom")
+	r := &errReader{data: []byte("G0 X0\n"), err: boom}
+	_, err := postProcess(r)
+	if err != boom {
+		t.Fatalf("expected %v, got %v", boom, err)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// errReader is an io.Reader that returns an error after the first Read.
+// errReader returns an error on the second read call.
 type errReader struct {
 	data []byte
 	read bool


### PR DESCRIPTION
## Summary
- make postProcess return scanner errors
- test error propagation using a failing reader

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68402ae64038832a94136141c03201bd