### PR TITLE
Fix path stripping for uploaded filenames

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,9 @@ func humanReadableSize(size int64) string {
 var reFilename = regexp.MustCompile(`^[\.\/\\~]+`)
 
 func normalizedFilename(filename string) string {
-	return reFilename.ReplaceAllString(filename, "")
+	filename = reFilename.ReplaceAllString(filename, "")
+	filename = strings.ReplaceAll(filename, "\\", "/")
+	return filepath.Base(filename)
 }
 
 /*

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestNormalizedFilename(t *testing.T) {
+	tests := map[string]string{
+		"foo.gcode":           "foo.gcode",
+		"../foo.gcode":        "foo.gcode",
+		"./foo.gcode":         "foo.gcode",
+		"~/foo.gcode":         "foo.gcode",
+		"dir1/foo.gcode":      "foo.gcode",
+		"dir1/dir2/foo.gcode": "foo.gcode",
+		"dir1\\foo.gcode":     "foo.gcode",
+		"C:\\tmp\\foo.gcode":  "foo.gcode",
+	}
+	for input, want := range tests {
+		got := normalizedFilename(input)
+		if got != want {
+			t.Errorf("normalizedFilename(%q)=%q, want %q", input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- normalize incoming filenames to remove directory components
- add regression tests for filename normalization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402ae110c4832aa019a67d0711c25b