### PR TITLE
Add environment variable reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ If `host` in `knownhosts`, `-host printer-id` is very convenient.
 
 Get help: `sm2uploader -h`
 
+## Environment Variables
+
+Several command line flags can also be configured via environment variables:
+
+- `HOST` - default value for `-host`, the printer id, hostname or IP.
+- `KNOWN_HOSTS` - path to the `hosts.yaml` file used for discovery cache.
+- `OCTOPRINT` - listen address for the OctoPrint compatible server.
+- `TOOL1`, `TOOL2` - preheat temperature for tool 1 and tool 2.
+- `BED` - bed preheat temperature.
+- `HOME` - when set to `true`, home the printer before upload.
+- `TIMEOUT` - discovery timeout duration, e.g. `3s`.
+- `NOFIX` - disable the built-in SMFix step.
+- `DEBUG` - enable debug logging.
+- `SLIC3R_PP_OUTPUT_NAME` - override the uploaded file name when called from PrusaSlicer.
+
 ## Fix the "can not be opened because it is from an unidentified developer"
 
 Solution: https://osxdaily.com/2012/07/27/app-cant-be-opened-because-it-is-from-an-unidentified-developer/

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -68,6 +68,21 @@ Request POST /api/files/local completed in 951.080458ms
 
 更多参数：`sm2uploader -h`
 
+## 环境变量
+
+以下环境变量与命令行参数对应，可用来预设默认值：
+
+- `HOST` - 对应 `-host`，指定打印机的 ID、主机名或 IP。
+- `KNOWN_HOSTS` - 保存发现记录的 `hosts.yaml` 路径。
+- `OCTOPRINT` - OctoPrint 兼容服务器的监听地址。
+- `TOOL1`, `TOOL2` - 工具 1 和 2 的预热温度。
+- `BED` - 热床预热温度。
+- `HOME` - 设为 `true` 时在上传前回原点。
+- `TIMEOUT` - 自动发现超时时间，如 `3s`。
+- `NOFIX` - 禁用内置的 SMFix 处理。
+- `DEBUG` - 输出调试信息。
+- `SLIC3R_PP_OUTPUT_NAME` - 从 PrusaSlicer 调用时覆盖上传的文件名。
+
 ## 在 macOS 系统提示文件无法打开的解决方法
 macOS 不允许直接打开未经数字签名的程序，参考解决方案: https://osxdaily.com/2012/07/27/app-cant-be-opened-because-it-is-from-an-unidentified-developer/
 


### PR DESCRIPTION
## Summary
- document environment variable usage in `README.md`
- add matching section to the Chinese README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402adb7294832abdbda2ea75560647