### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download [sm2uploader](https://github.com/macdylan/sm2uploader/releases)
 for Windows:
  - locate to the sm2uploader folder, and double-click `start-octoprint.bat`
  - type a port number for octoprint that you wish to listen
- - when `Server started ...` message appears, the startup was successful, do not close the cmd window, and go to the slicer software to setup a OctoPrint printer
+ - when `Server started ...` message appears, the startup was successful, do not close the command prompt window, and go to the slicer software to setup a OctoPrint printer
  - use `http://127.0.0.1:(PORT NUM)` as url, click the Test Connect button, all configuration will be finished if successful.
 
 ```bash


### PR DESCRIPTION
## Summary
- replace "cmd window" with "command prompt window"

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402ad9118c832a8efa13de8193d0a6