### PR TITLE
Fix broadcast mask for discovery

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -117,11 +117,10 @@ func getBroadcastAddresses() ([]string, error) {
 		for _, addr := range addrs {
 			if n, ok := addr.(*net.IPNet); ok && !n.IP.IsLoopback() {
 				if v4addr := n.IP.To4(); v4addr != nil {
-					// convert all parts of the masked bits to its maximum value
-					// by converting the address into a 32 bit integer and then
-					// ORing it with the inverted mask
+					// compute the broadcast address by ORing the IPv4 address
+					// with the inverted network mask
 					baddr := make(net.IP, len(v4addr))
-					binary.BigEndian.PutUint32(baddr, binary.BigEndian.Uint32(v4addr)|^binary.BigEndian.Uint32(n.IP.DefaultMask()))
+					binary.BigEndian.PutUint32(baddr, binary.BigEndian.Uint32(v4addr)|^binary.BigEndian.Uint32(n.Mask))
 					if s := baddr.String(); !addrMap[s] {
 						addrMap[s] = true
 					}


### PR DESCRIPTION
## Summary
- compute broadcast addresses using the actual subnet mask
- update the surrounding comment to describe the computation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68402ad2aa2c832a84f1a8aad96e8736