### PR TITLE
Fix package count calculation and add tests

### DIFF
--- a/sacp.go
+++ b/sacp.go
@@ -312,7 +312,7 @@ func SACP_send_command(conn net.Conn, command_set uint8, command_id uint8, data 
 
 func SACP_start_upload(conn net.Conn, filename string, gcode []byte, timeout time.Duration) error {
 	// prepare data for upload begin packet
-	package_count := uint16((len(gcode) / SACP_data_len) + 1)
+	package_count := uint16((len(gcode) + SACP_data_len - 1) / SACP_data_len)
 	md5hash := md5.Sum(gcode)
 
 	data := bytes.Buffer{}

--- a/sacp_test.go
+++ b/sacp_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
 
 func TestSACPDecodeValid(t *testing.T) {
 	orig := SACP_pack{
@@ -41,5 +48,61 @@ func TestSACPDecodeInvalidHeader(t *testing.T) {
 	err := got.Decode(encoded)
 	if err != errInvalidSACP {
 		t.Fatalf("expected errInvalidSACP, got %v", err)
+	}
+}
+
+// recordingConn is a minimal net.Conn implementation that captures written bytes.
+type recordingConn struct{ bytes.Buffer }
+
+func (r *recordingConn) Read(b []byte) (int, error)         { return 0, io.EOF }
+func (r *recordingConn) Write(b []byte) (int, error)        { return r.Buffer.Write(b) }
+func (r *recordingConn) Close() error                       { return nil }
+func (r *recordingConn) LocalAddr() net.Addr                { return nil }
+func (r *recordingConn) RemoteAddr() net.Addr               { return nil }
+func (r *recordingConn) SetDeadline(t time.Time) error      { return nil }
+func (r *recordingConn) SetReadDeadline(t time.Time) error  { return nil }
+func (r *recordingConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func getPackageCountFromStartPacket(b []byte) (uint16, error) {
+	var p SACP_pack
+	if err := p.Decode(b); err != nil {
+		return 0, err
+	}
+	if len(p.Data) < 2 {
+		return 0, errInvalidSize
+	}
+	nameLen := binary.LittleEndian.Uint16(p.Data[:2])
+	off := 2 + int(nameLen)
+	if len(p.Data) < off+4+2 {
+		return 0, errInvalidSize
+	}
+	off += 4
+	pkgCount := binary.LittleEndian.Uint16(p.Data[off : off+2])
+	return pkgCount, nil
+}
+
+func TestPackageCountExactMultiple(t *testing.T) {
+	gcode := make([]byte, SACP_data_len*2)
+	conn := &recordingConn{}
+	_ = SACP_start_upload(conn, "f.gcode", gcode, time.Millisecond)
+	pkgCount, err := getPackageCountFromStartPacket(conn.Bytes())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if pkgCount != 2 {
+		t.Fatalf("expected package count 2, got %d", pkgCount)
+	}
+}
+
+func TestPackageCountNonExactMultiple(t *testing.T) {
+	gcode := make([]byte, SACP_data_len*2+123)
+	conn := &recordingConn{}
+	_ = SACP_start_upload(conn, "f.gcode", gcode, time.Millisecond)
+	pkgCount, err := getPackageCountFromStartPacket(conn.Bytes())
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if pkgCount != 3 {
+		t.Fatalf("expected package count 3, got %d", pkgCount)
 	}
 }


### PR DESCRIPTION
## Summary
- correct calculation of `package_count`
- verify new `package_count` logic with tests for exact/non-exact multiples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402ad04540832a9e53b241d642c4ae