### PR TITLE
Capture w.Write errors

### DIFF
--- a/octoprint.go
+++ b/octoprint.go
@@ -186,7 +186,9 @@ func writeResponse(w http.ResponseWriter, status int, body string) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	}
 	w.WriteHeader(status)
-	w.Write([]byte(body))
+	if _, err := w.Write([]byte(body)); err != nil {
+		log.Printf("write response error: %v", err)
+	}
 }
 
 func methodNotAllowedResponse(w http.ResponseWriter, method string) {


### PR DESCRIPTION
## Summary
- check Write errors in SACP helpers
- propagate errors when building SACP requests
- log Write errors when sending HTTP responses

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402acf5cb0832ab5613ce6c085802b