### PR TITLE
Propagate scanner errors in postProcess

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -77,6 +77,10 @@ func postProcess(r io.Reader) (out []byte, err error) {
 		}
 	}
 
+	if err = sc.Err(); err != nil {
+		return nil, err
+	}
+
 	if !isFixed {
 		funcs := []fix.GcodeModifier{}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+type errReader struct{ err error }
+
+func (e errReader) Read(p []byte) (int, error) { return 0, e.err }
+
+func TestPostProcessPropagatesScannerError(t *testing.T) {
+	testErr := errors.New("boom")
+	_, err := postProcess(errReader{err: testErr})
+	if err != testErr {
+		t.Fatalf("expected %v, got %v", testErr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- return `Scanner` errors from `postProcess`
- add regression test for the scanner error handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402acc4bf4832a9854a3c396b235f1