### PR TITLE
Handle HTTP upload pipe write errors

### DIFF
--- a/connector_http.go
+++ b/connector_http.go
@@ -150,6 +150,7 @@ func (hc *HTTPConnector) Upload(payload *Payload) (err error) {
 		w.Stop()
 		log.SetOutput(os.Stderr)
 	}()
+	var writeErr error
 
 	file := req.FileUpload{
 		ParamName: "file",
@@ -157,7 +158,6 @@ func (hc *HTTPConnector) Upload(payload *Payload) (err error) {
 		GetFileContent: func() (io.ReadCloser, error) {
 			pr, pw := io.Pipe()
 			go func() {
-				defer pw.Close()
 				content, err := payload.GetContent(NoFix)
 				if !NoFix {
 					log.SetOutput(os.Stderr)
@@ -168,7 +168,12 @@ func (hc *HTTPConnector) Upload(payload *Payload) (err error) {
 					}
 					log.SetOutput(w)
 				}
-				pw.Write(content)
+				if _, werr := pw.Write(content); werr != nil {
+					writeErr = werr
+					pw.CloseWithError(werr)
+					return
+				}
+				pw.Close()
 			}()
 			return pr, nil
 		},
@@ -196,6 +201,11 @@ func (hc *HTTPConnector) Upload(payload *Payload) (err error) {
 		}
 	} else {
 		_, err = r.Post(hc.URL("/upload"))
+	}
+	if err == nil && writeErr != nil {
+		err = writeErr
+	} else if writeErr != nil {
+		log.Printf("HTTP upload write error: %v", writeErr)
 	}
 	return
 }


### PR DESCRIPTION
## Summary
- log and return pipe write errors when streaming file data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402acb739c832ab818193db6aca625