### PR TITLE
Refactor argument parsing for OctoPrint uploads

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -18,10 +18,11 @@ var (
 )
 
 type Payload struct {
-	File io.Reader
-	Name string
-	Size int64
-	Print bool
+	File    io.Reader
+	Name    string
+	Size    int64
+	Print   bool
+	Options FixOptions
 }
 
 func (p *Payload) SetName(name string) {
@@ -36,7 +37,7 @@ func (p *Payload) GetContent(nofix bool) (cont []byte, err error) {
 	if nofix || !p.ShouldBeFix() {
 		cont, err = io.ReadAll(p.File)
 	} else {
-		cont, err = postProcess(p.File)
+		cont, err = postProcess(p.File, p.Options)
 		p.Size = int64(len(cont))
 	}
 	return cont, err
@@ -48,10 +49,11 @@ func (p *Payload) ShouldBeFix() bool {
 
 func NewPayload(file io.Reader, name string, size int64, print bool) *Payload {
 	return &Payload{
-		File: file,
-		Name: normalizedFilename(name),
-		Size: size,
-		Print: print,
+		File:    file,
+		Name:    normalizedFilename(name),
+		Size:    size,
+		Print:   print,
+		Options: FixOptions{},
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,13 @@ import (
 	"github.com/macdylan/SMFix/fix"
 )
 
+// FixOptions controls how smfix modifies a gcode file.
+type FixOptions struct {
+	NoTrim        bool
+	NoShutoff     bool
+	NoReplaceTool bool
+}
+
 type empty struct{}
 
 func humanReadableSize(size int64) string {
@@ -37,17 +44,17 @@ func normalizedFilename(filename string) string {
 }
 
 /*
-func postProcessFile(file_path string) (out []byte, err error) {
-	var r *os.File
-	if r, err = os.Open(file_path); err != nil {
-		return
-	}
-	defer r.Close()
-	return postProcess(r)
+func postProcessFile(file_path string, opts FixOptions) (out []byte, err error) {
+        var r *os.File
+        if r, err = os.Open(file_path); err != nil {
+                return
+        }
+        defer r.Close()
+        return postProcess(r, opts)
 }
 */
 
-func postProcess(r io.Reader) (out []byte, err error) {
+func postProcess(r io.Reader, opts FixOptions) (out []byte, err error) {
 	var (
 		isFixed = false
 		nl      = []byte("\n")
@@ -80,16 +87,16 @@ func postProcess(r io.Reader) (out []byte, err error) {
 	if !isFixed {
 		funcs := []fix.GcodeModifier{}
 
-		if !noTrim {
+		if !opts.NoTrim {
 			// funcs = append(funcs, fix.GcodeTrimLines)
 		}
-		if !noShutoff {
+		if !opts.NoShutoff {
 			funcs = append(funcs, fix.GcodeFixShutoff)
 		}
 		// if !noPreheat {
 		// 	funcs = append(funcs, fix.GcodeFixPreheat)
 		// }
-		if !noReplaceTool {
+		if !opts.NoReplaceTool {
 			funcs = append(funcs, fix.GcodeReplaceToolNum)
 		}
 		// if !noReinforceTower {


### PR DESCRIPTION
## Summary
- return `FixOptions` from `argumentsFromApi`
- add options to `Payload` and apply them in `postProcess`
- pass options in OctoPrint upload handler

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402aca49b0832abf6c777518789290