### PR TITLE
Fix SACP timeout handling

### DIFF
--- a/sacp.go
+++ b/sacp.go
@@ -344,7 +344,7 @@ func SACP_start_upload(conn net.Conn, filename string, gcode []byte, timeout tim
 	for {
 		// always receive packet, then send response
 		conn.SetReadDeadline(time.Now().Add(timeout))
-		p, err := SACP_read(conn, time.Second*10)
+		p, err := SACP_read(conn, timeout)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- propagate timeout argument inside `SACP_start_upload`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402ac98a68832abedcd9b4db0e83bf