### PR TITLE
doc: clarify interface mask usage

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -117,11 +117,11 @@ func getBroadcastAddresses() ([]string, error) {
 		for _, addr := range addrs {
 			if n, ok := addr.(*net.IPNet); ok && !n.IP.IsLoopback() {
 				if v4addr := n.IP.To4(); v4addr != nil {
-					// convert all parts of the masked bits to its maximum value
-					// by converting the address into a 32 bit integer and then
-					// ORing it with the inverted mask
+					// Convert the masked bits to their maximum value by
+					// OR'ing the address with the inverted interface mask
+					// (n.Mask) after converting both to 32-bit integers.
 					baddr := make(net.IP, len(v4addr))
-					binary.BigEndian.PutUint32(baddr, binary.BigEndian.Uint32(v4addr)|^binary.BigEndian.Uint32(n.IP.DefaultMask()))
+					binary.BigEndian.PutUint32(baddr, binary.BigEndian.Uint32(v4addr)|^binary.BigEndian.Uint32(n.Mask))
 					if s := baddr.String(); !addrMap[s] {
 						addrMap[s] = true
 					}


### PR DESCRIPTION
## Summary
- clarify comment about broadcast address
- use interface mask when forming the broadcast address

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402ac43450832a965e1bdd4d13f79f